### PR TITLE
micro typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ One can also clone the repository and manually install the package:
 
 ```
 git clone https://github.com/ion-g-ion/torchTT
-cd torchtt
+cd torchTT
 python setup.py install
 ``` 
 


### PR DESCRIPTION
micro typo in the readme.

the other option would be to rename the cloned repo but that would be too verbose.

best,
N

  