### PR TITLE
LU decomposition fix

### DIFF
--- a/torchtt/interpolate.py
+++ b/torchtt/interpolate.py
@@ -23,10 +23,8 @@ def _LU(M):
         tuple[torch.tensor,torch.tensor,torch.tensor]: L, U, P
     """
     LU, P = tn.linalg.lu_factor(M)
-    P, L, U = tn.lu_unpack(LU, P)  # P transpose or not transpose?
-    P = P@tn.reshape(tn.arange(P.shape[1],
-                     dtype=P.dtype, device=P.device), [-1, 1])
-    # P = tn.reshape(tn.arange(P.shape[1],dtype=P.dtype,device=P.device),[1,-1]) @ P
+    P, L, U = tn.lu_unpack(LU, P)
+    P = tn.reshape(tn.arange(P.shape[1],dtype=P.dtype,device=P.device),[1,-1]) @ P
 
     return L, U, tn.squeeze(P).to(tn.int64)
 


### PR DESCRIPTION
Hi Ion,

We have been experimenting with your project for cross interpolation purposes and have noticed that this error occurs.

```
  File ".../torchtt/interpolate.py", line 726, in dmrg_cross
    idx = _maxvol(Qmat)
  File ".../torchtt/interpolate.py", line 66, in _maxvol
    Mat = tn.linalg.solve(Msub.T, M.T).t()
torch._C._LinAlgError: torch.linalg.solve: The solver failed because the input matrix is singular.

```
If the [commented approach](https://github.com/ion-g-ion/torchTT/blob/495b8e31a36fa89353d45a26f477e14adbcd78ee/torchtt/interpolate.py#L25-L29) is used in the LU decomposition, the error does not occur. We believe this happens because PyTorch returns the inverse of the pivot matrix.